### PR TITLE
2 vs 3 testing for string formatting

### DIFF
--- a/pysal/core/IOHandlers/pyDbfIO.py
+++ b/pysal/core/IOHandlers/pyDbfIO.py
@@ -70,8 +70,8 @@ class DBF(pysal.core.Tables.DataTable):
                 name, typ, size, deci = struct.unpack(
                     '<11sc4xBB14x', f.read(32))
                 if PY3:
-                    strname = str(name, 'utf-8')
-                    name = bytes(strname, 'utf-8')
+                    name = str(name, 'utf-8')
+                    name = name.strip('\x00')
                 else:
                     name = name.replace('\0', '')
                 self._col_index[name] = (idx, record_size)


### PR DESCRIPTION
Figured you'd take this. 

With all the junk involved in strings vs. bytestrings changing in python3, I think it might be easier to just be very explicit about what methods are used where.

`2to3` won't push an explicit `utf-8` format into `str()`.  I think just doing an explicit version check might be easiest. This looks like it's a real thorny issue for many projects that used `stringIO` in python 2. 

Otherwise, this still fails in `3.4`, but I think it's failing because it's trying to read too many rows. It fails on the 49th iteration of `read_record`, which means it's trying to read one more record than exists in the table. If I can just figure out what the right exception is to raise and where to raise it, I think we're in business for the `_read` methods.
