### PR TITLE
remove six

### DIFF
--- a/pysal/core/IOHandlers/tests/test_csvWrapper.py
+++ b/pysal/core/IOHandlers/tests/test_csvWrapper.py
@@ -2,7 +2,9 @@ import unittest
 import pysal
 import tempfile
 import os
-import six
+from sys import version as V
+
+PY3 = int(V[0]) > 2
 
 class test_csvWrapper(unittest.TestCase):
     def setUp(self):
@@ -42,13 +44,12 @@ class test_csvWrapper(unittest.TestCase):
     def test_casting(self):
         self.obj.cast('WKT', pysal.core.util.WKTParser())
         verts = [(-89.585220336914062, 39.978794097900391), (-89.581146240234375, 40.094867706298828), (-89.603988647460938, 40.095306396484375), (-89.60589599609375, 40.136119842529297), (-89.6103515625, 40.3251953125), (-89.269027709960938, 40.329566955566406), (-89.268562316894531, 40.285579681396484), (-89.154655456542969, 40.285774230957031), (-89.152763366699219, 40.054969787597656), (-89.151618957519531, 39.919403076171875), (-89.224777221679688, 39.918678283691406), (-89.411857604980469, 39.918041229248047), (-89.412437438964844, 39.931644439697266), (-89.495201110839844, 39.933486938476562), (-89.4927978515625, 39.980186462402344), (-89.585220336914062, 39.978794097900391)]
-        if six.PY2:
-            for i, pt in enumerate(self.obj.next()[0].vertices):
-                self.assertEquals(pt[:], verts[i])
-        elif six.PY3:
+        if PY3:
             for i, pt in enumerate(self.obj.__next__()[0].vertices):
                 self.assertEquals(pt[:], verts[i])
-
+        else:
+            for i, pt in enumerate(self.obj.next()[0].vertices):
+                self.assertEquals(pt[:], verts[i])
 
     def test_by_col(self):
         for field in self.obj.header:

--- a/pysal/core/IOHandlers/tests/test_pyDbfIO.py
+++ b/pysal/core/IOHandlers/tests/test_pyDbfIO.py
@@ -4,9 +4,6 @@ import unittest
 import pysal
 import tempfile
 import os
-from six.moves import range
-from six.moves import zip
-
 
 class test_DBF(unittest.TestCase):
     def setUp(self):

--- a/pysal/core/util/shapefile.py
+++ b/pysal/core/util/shapefile.py
@@ -15,14 +15,18 @@ http://geodacenter.asu.edu
 __author__ = "Charles R Schmidt <schmidtc@gmail.com>"
 
 from struct import calcsize, unpack, pack
-import six
-if six.PY3:
-    import io
-elif six.PY2:
-    from cStringIO import StringIO
+
 from itertools import izip, islice
 import array
 import sys
+
+PY3 = int(sys.version[0]) > 2
+
+if PY3:
+    import io
+else:
+    from cStringIO import StringIO
+
 if sys.byteorder == 'little':
     SYS_BYTE_ORDER = '<'
 else:
@@ -39,10 +43,10 @@ def bufferIO(buf):
     """
     Helper function for 2-3 compatibility
     """
-    if six.PY2:
-        return StringIO(buf)
-    elif six.PY3:
+    if PY3:
         return io.BytesIO(buf)
+    else:
+        return StringIO(buf)
 
 def struct2arrayinfo(struct):
     struct = list(struct)

--- a/pysal/core/util/tests/test_shapefile.py
+++ b/pysal/core/util/tests/test_shapefile.py
@@ -1,9 +1,10 @@
 import unittest
-import six
 
-if six.PY3:
+import sys
+PY3 = int(sys.version[0]) > 2
+if PY3:
     import io
-elif six.PY2:
+else:
     from cStringIO import StringIO
 
 from pysal.core.util.shapefile import noneMax, noneMin, shp_file, shx_file, NullShape, Point, PolyLine, MultiPoint, PointZ, PolyLineZ, PolygonZ, MultiPointZ, PointM, PolyLineM, PolygonM, MultiPointM, MultiPatch
@@ -14,9 +15,9 @@ def bufferIO(buf):
     """
     Temp stringIO function to force compat
     """
-    if six.PY3:
+    if PY3:
         return io.BytesIO(buf)
-    elif six.PY2:
+    else:
         return StringIO(buf)
 
 class TestNoneMax(unittest.TestCase):


### PR DESCRIPTION
Just a super small removal of `six` usage in the `core` module. 

Now, grep only shows matches for six in `virginia_queen.mat`