### PR TITLE
cleaning up unused imports & versioning in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ python:
 before_install:
   - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
-  - ./miniconda.sh -b
-  - export PATH=/home/travis/miniconda/bin:$PATH
+  - ./miniconda.sh -b -p ./miniconda
+  - export PATH=`pwd`/miniconda/bin:$PATH
   - conda update --yes conda
   - conda create -y -q -n test-env python=$TRAVIS_PYTHON_VERSION
   - source activate test-env

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,13 @@
 # coding: utf-8
 
-try:
-    from setuptools import setup, find_packages
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup, find_packages
 
 try:
     from distutils.command.build_py import build_py_2to3 as build_py
 except ImportError:
     from distutils.command.build_py import build_py
 
-import sys
-import shutil
 import os
-if sys.version_info[0] < 3:
-    import __builtin__ as builtins
-else:
-    import builtins
-
-from version import version as dversion
 
 with open('README.rst') as file:
     long_description = file.read()
@@ -56,7 +45,7 @@ def setup_package():
 
     setup(
         name='PySAL',
-        version=dversion,
+        version=VERSION,
         description="A library of spatial analysis functions.",
         long_description=long_description,
         maintainer="PySAL Developers",


### PR DESCRIPTION
This does some small cleaning on the setup file. 

First, we need `setuptools` for its `find_packages`. if importing `setuptools` fails, `setup` wil fail with the `find_packages` call being undefined. Removing the conditional gives us an accurate point of failure if the user doesn't have setuptools. 

We're not using the `builtins`  (or `__builins__`) module anywhere. Ditto for `shutil`, and `sys` is only used for a version test for `builtins`. 

The `VERSION` variable in file should probably be what's used by the setup script, so that everything is consistent. 

I can ship this to upstream/dev if that's where this belongs instead. I just did this while working on the 2to3 distribution problem. 