### PR TITLE
missed one floordiv in merge

### DIFF
--- a/pysal/spreg/diagnostics.py
+++ b/pysal/spreg/diagnostics.py
@@ -906,10 +906,10 @@ def white(reg):
 
     # Compute cross-products and squares of the regression variables
     if type(X).__name__ == 'ndarray':
-        A = np.zeros((n, (k * (k + 1)) / 2))
+        A = np.zeros((n, (k * (k + 1)) // 2))
     elif type(X).__name__ == 'csc_matrix' or type(X).__name__ == 'csr_matrix':
         # this is probably inefficient
-        A = SP.lil_matrix((n, (k * (k + 1)) / 2))
+        A = SP.lil_matrix((n, (k * (k + 1)) // 2))
     else:
         raise Exception, "unknown X type, %s" % type(X).__name__
     counter = 0


### PR DESCRIPTION
This was a floor division I missed while merging. It's in `spreg.diagnostics.white`. I don't think omitting it causes test failure, but using `np.zeros((float1, float2))` raises a deprecation warning and will generate errors in the future. 