### PR TITLE
Add initial tests for pointpattern and some code improvement in pointpattern.py 

### DIFF
--- a/pysal/contrib/points/pointpattern.py
+++ b/pysal/contrib/points/pointpattern.py
@@ -284,7 +284,8 @@ class PointPattern(object):
                row i column j contains the distance between i and its jth
                nearest neighbor
         """
-
+        if k < 1:
+            raise ValueError('k must be at least 1')
         nn = self.tree.query(self.tree.data, k=k+1)
         return nn[1][:, 1:], nn[0][:, 1:]
 
@@ -359,7 +360,8 @@ class PointPattern(object):
                row i column j contains the distance between i and its jth
                nearest neighbor
         """
-
+        if k < 1:
+            raise ValueError('k must be at least 1')
         try:
             nn = self.tree.query(other.points, k=k)
         except:

--- a/pysal/contrib/points/pointpattern.py
+++ b/pysal/contrib/points/pointpattern.py
@@ -46,9 +46,9 @@ class PointPattern(object):
 
     >>> from pysal.contrib.points.pointpattern import PointPattern
     >>> points = [[66.22, 32.54], [22.52, 22.39], [31.01, 81.21],
-                  [9.47, 31.02], [30.78, 60.10], [75.21, 58.93],
-                  [79.26,  7.68], [8.23, 39.93], [98.73, 77.17],
-                  [89.78, 42.53], [65.19, 92.08], [54.46, 8.48]]
+    ...           [9.47, 31.02], [30.78, 60.10], [75.21, 58.93],
+    ...           [79.26,  7.68], [8.23, 39.93], [98.73, 77.17],
+    ...           [89.78, 42.53], [65.19, 92.08], [54.46, 8.48]]
     >>> pp = PointPattern(points)
     >>> pp.n
     12
@@ -93,6 +93,38 @@ class PointPattern(object):
             self.set_window(window)
 
         self._facade()
+
+    def __len__(self):
+        """Return the number of points. Use the expression 'len(pp)'.
+
+        Returns
+        -------
+        length : int
+            The number of points in the point pattern.
+
+        Examples
+        --------
+        >>> points = [[1, 3], [4, 5], [0,0]]
+        >>> pp = PointPattern(points)
+        >>> len(pp)
+        3
+
+        """
+        return len(self.df)
+
+    def __contains__(self, n):
+        """Return True if n is a point (a tuple of coordinates), False otherwise.
+        Use the expression 'n in pp'.
+
+        Examples
+        --------
+        >>> points = [[1, 3], [4, 5], [0,0]]
+        >>> pp = PointPattern(points)
+        >>> [1, 3] in pp
+        True
+        """
+        name = self.df.columns.values.tolist()
+        return ((self.df[name[0]] == n[0]) & (self.df[name[1]] == n[1])).any()
 
     def set_window(self, window):
         try:

--- a/pysal/contrib/points/tests/test_pointpattern.py
+++ b/pysal/contrib/points/tests/test_pointpattern.py
@@ -55,6 +55,9 @@ class TestPointPattern(unittest.TestCase):
         np.testing.assert_array_equal(knn[0], nn)
         np.testing.assert_array_almost_equal(knn[1], nnd)
 
+    def test_point_pattern_knn_error(self):
+        self.assertRaises(ValueError, self.pp.knn, k=0)
+
     def test_point_pattern_knn_other(self):
         knn = self.pp.knn_other(self.pp)
         nn = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
@@ -69,6 +72,10 @@ class TestPointPattern(unittest.TestCase):
                        95.54731289, 99.34409545, 112.82048794, 125.31090056])
         np.testing.assert_array_equal(knn[0], nn)
         np.testing.assert_array_almost_equal(knn[1], nnd)
+
+    def test_point_pattern_knn_other_error(self):
+        knn_other = self.pp.knn_other
+        self.assertRaises(ValueError, knn_other, self.pp, k=0)
 
     def test_point_pattern_explode(self):
         explosion = self.pp.explode('x')

--- a/pysal/contrib/points/tests/test_pointpattern.py
+++ b/pysal/contrib/points/tests/test_pointpattern.py
@@ -13,6 +13,8 @@ class TestPointPattern(unittest.TestCase):
                   [79.26,  7.68], [8.23, 39.93], [98.73, 77.17],
                   [89.78, 42.53], [65.19, 92.08], [54.46, 8.48]]
         self.pp = PointPattern(points)
+        self.assertEqual(len(self.pp), 12)
+        self.assertTrue([66.22, 32.54] in self.pp)
 
     def test_point_pattern_n(self):
         self.assertEqual(self.pp.n, 12)

--- a/pysal/contrib/points/tests/test_pointpattern.py
+++ b/pysal/contrib/points/tests/test_pointpattern.py
@@ -44,6 +44,17 @@ class TestPointPattern(unittest.TestCase):
         self.assertEqual(self.pp.find_pairs(10), {(3, 7)})
         self.assertEqual(self.pp.find_pairs(20), {(3, 7), (1, 3)})
 
+    def test_point_pattern_knn(self):
+        knn = self.pp.knn(1)
+        nn = np.array([[9], [3], [4], [7], [2], [9], [11], [3], [5], [5], [5],
+                      [6]])
+        nnd = np.array([[25.59050019], [15.64542745], [21.11125292],
+                        [8.99587128], [21.11125292], [21.93729473],
+                        [24.81289987], [8.99587128], [29.76387072],
+                        [21.93729473], [34.63124168], [24.81289987]])
+        np.testing.assert_array_equal(knn[0], nn)
+        np.testing.assert_array_almost_equal(knn[1], nnd)
+
     def test_point_pattern_knn_other(self):
         knn = self.pp.knn_other(self.pp)
         nn = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
@@ -58,3 +69,9 @@ class TestPointPattern(unittest.TestCase):
                        95.54731289, 99.34409545, 112.82048794, 125.31090056])
         np.testing.assert_array_equal(knn[0], nn)
         np.testing.assert_array_almost_equal(knn[1], nnd)
+
+    def test_point_pattern_explode(self):
+        explosion = self.pp.explode('x')
+        for ppattern in explosion:
+            np.testing.assert_array_equal(ppattern.df.iloc[0],
+                                          self.pp.df.loc[ppattern.df.index[0]])

--- a/pysal/contrib/points/tests/test_pointpattern.py
+++ b/pysal/contrib/points/tests/test_pointpattern.py
@@ -1,0 +1,60 @@
+import unittest
+import numpy as np
+
+from pysal.contrib.points.pointpattern import PointPattern
+from pysal.common import RTOL
+
+
+class TestPointPattern(unittest.TestCase):
+
+    def setUp(self):
+        points = [[66.22, 32.54], [22.52, 22.39], [31.01, 81.21],
+                  [9.47, 31.02], [30.78, 60.10], [75.21, 58.93],
+                  [79.26,  7.68], [8.23, 39.93], [98.73, 77.17],
+                  [89.78, 42.53], [65.19, 92.08], [54.46, 8.48]]
+        self.pp = PointPattern(points)
+
+    def test_point_pattern_n(self):
+        self.assertEqual(self.pp.n, 12)
+
+    def test_point_pattern_mean_nnd(self):
+        np.testing.assert_allclose(self.pp.mean_nnd, 21.612139802089246, RTOL)
+
+    def test_point_pattern_lambda_mbb(self):
+        np.testing.assert_allclose(self.pp.lambda_mbb,
+                                   0.0015710507711240867, RTOL)
+
+    def test_point_pattern_lambda_hull(self):
+        np.testing.assert_allclose(self.pp.lambda_hull,
+                                   0.0022667153468973137, RTOL)
+
+    def test_point_pattern_hull_area(self):
+        np.testing.assert_allclose(self.pp.hull_area, 5294.0039500000003, RTOL)
+
+    def test_point_pattern_mbb_area(self):
+        np.testing.assert_allclose(self.pp.mbb_area, 7638.2000000000007, RTOL)
+
+    def test_point_pattern_min_nnd(self):
+        np.testing.assert_allclose(self.pp.min_nnd, 8.9958712752017522, RTOL)
+
+    def test_point_pattern_max_nnd(self):
+        np.testing.assert_allclose(self.pp.max_nnd, 34.63124167568931, RTOL)
+
+    def test_point_pattern_find_pairs(self):
+        self.assertEqual(self.pp.find_pairs(10), {(3, 7)})
+        self.assertEqual(self.pp.find_pairs(20), {(3, 7), (1, 3)})
+
+    def test_point_pattern_knn_other(self):
+        knn = self.pp.knn_other(self.pp)
+        nn = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+        nnd = np.zeros(12)
+        np.testing.assert_array_equal(knn[0], nn)
+        np.testing.assert_array_equal(knn[1], nnd)
+
+        knn = self.pp.knn_other([0, 0], k=12)
+        nn = np.array([1, 3, 7, 11, 4, 0, 6, 2, 5, 9, 10, 8])
+        nnd = np.array([31.75629859, 32.43333625, 40.76932425, 55.11625894,
+                       67.52346555, 73.78306039, 79.63121247, 86.92919072,
+                       95.54731289, 99.34409545, 112.82048794, 125.31090056])
+        np.testing.assert_array_equal(knn[0], nn)
+        np.testing.assert_array_almost_equal(knn[1], nnd)


### PR DESCRIPTION
Wrote some boilerplate test code for point pattern class. [needs more work]

In the function `knn_other`, if we pass `k=x` where `x > the number of points` it still works but returns the distance as `inf`. Is this a design decision?

@sjsrey 