### PR TITLE
install mandatories first, then install optionals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ before_install:
 
 install:
   - conda install --yes pip
+  - pip install -r requirements.txt;
   - if [ "$PYSAL_PLUS" == true ]; then
         echo 'plus testing'; conda install --yes --file requirements_plus.txt;
-        else conda install --yes --file requirements.txt;
     fi;
   - pip install -r requirements_dev.txt
 


### PR DESCRIPTION
popping this out seems to fix the issues w/ the install script. It ensures that we pull all submodules always & only enhance if we're in pysal plus. 