### PR TITLE
correcting spaghetti docs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -502,16 +502,16 @@ spaghetti
 .. autosummary::
    :toctree: generated/
    
-   spaghetti.spaghetti.compute_length
-   spaghetti.spaghetti.dijkstra
-   spaghetti.spaghetti.dijkstra_mp
-   spaghetti.spaghetti.generatetree
-   spaghetti.spaghetti.get_neighbor_distances
-   spaghetti.spaghetti.snap_points_on_segments
-   spaghetti.spaghetti.squared_distance_point_segment
-   spaghetti.spaghetti.ffunction
-   spaghetti.spaghetti.gfunction
-   spaghetti.spaghetti.kfunction
+   spaghetti.compute_length
+   spaghetti.dijkstra
+   spaghetti.dijkstra_mp
+   spaghetti.generatetree
+   spaghetti.get_neighbor_distances
+   spaghetti.snap_points_on_segments
+   spaghetti.squared_distance_point_segment
+   spaghetti.ffunction
+   spaghetti.gfunction
+   spaghetti.kfunction
 
 
 .. currentmodule:: pysal.viz


### PR DESCRIPTION
The justification for this PR is: 

[correcting `docs` issues for `spaghetti` found by @sjsrey](
https://gitter.im/pysal/pysal?at=5c2023376649aa1f82bf489a)