### PR TITLE
change napoleon to numpydoc for docstring support in Sphinx

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
-SPHINXPROJ    = PACKAGE_NAME
+SPHINXPROJ    = pysal
 SOURCEDIR     = .
 BUILDDIR      = _build
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -42,7 +42,8 @@ extensions = [#'sphinx_gallery.gen_gallery',
               'sphinx.ext.mathjax',
               'sphinx.ext.doctest',
               'sphinx.ext.intersphinx',
-              'sphinx.ext.napoleon',
+              'numpydoc',
+              #'sphinx.ext.napoleon',
               'matplotlib.sphinxext.plot_directive']
 
 

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -9,7 +9,7 @@ if "%SPHINXBUILD%" == "" (
 )
 set SOURCEDIR=.
 set BUILDDIR=_build
-set SPHINXPROJ=PACKAGE_NAME
+set SPHINXPROJ=pysal
 
 if "%1" == "" goto help
 


### PR DESCRIPTION
This PR is to change `napoleon` to `numpydoc` to support docstring formatting in sphinx so that figures can be properly generated and rendered for inline interactive examples.
