### PR TITLE
test all functions using lazy import structure

### DIFF
--- a/pysal/tests/test_imports.py
+++ b/pysal/tests/test_imports.py
@@ -1,20 +1,8 @@
-def test_import():
-    from pysal.lib import cg
-    from pysal.lib import io 
-    from pysal.lib import weights
-    from pysal.lib import examples
-    from pysal.explore import giddy
-    from pysal.explore import esda
-    from pysal.explore import inequality
-    from pysal.explore import segregation
-    from pysal.explore import pointpats
-    from pysal.explore import spaghetti
-    from pysal.model import tobler
-    from pysal.model import mgwr
-    from pysal.model import spreg
-    from pysal.model import spint
-    from pysal.model import spvcm
-    from pysal.model import spglm
-    from pysal.viz import mapclassify
-    from pysal.viz import splot
+import pkgutil
+import pysal
 
+__all__ = []
+for loader, module_name, is_pkg in  pkgutil.walk_packages(pysal.__path__):
+    __all__.append(module_name)
+    _module = loader.find_module(module_name).load_module(module_name)
+    globals()[module_name] = _module


### PR DESCRIPTION
this tests that all functions import successfully using the new lazy structure--just in time, because it finds an error in access :P

`E   ImportError: cannot import name 'access_log_stream' from 'access'`